### PR TITLE
Update org name everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Pathfinder.jl: Parallel quasi-Newton variational inference
 
-[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://sethaxen.github.io/Pathfinder.jl/stable)
-[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://sethaxen.github.io/Pathfinder.jl/dev)
-[![Build Status](https://github.com/sethaxen/Pathfinder.jl/workflows/CI/badge.svg)](https://github.com/sethaxen/Pathfinder.jl/actions)
-[![Coverage](https://codecov.io/gh/sethaxen/Pathfinder.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/sethaxen/Pathfinder.jl)
+[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://mlcolab.github.io/Pathfinder.jl/stable)
+[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://mlcolab.github.io/Pathfinder.jl/dev)
+[![Build Status](https://github.com/mlcolab/Pathfinder.jl/workflows/CI/badge.svg)](https://github.com/mlcolab/Pathfinder.jl/actions)
+[![Coverage](https://codecov.io/gh/mlcolab/Pathfinder.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/mlcolab/Pathfinder.jl)
 [![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/invenia/BlueStyle)
 [![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.5914976.svg)](https://doi.org/10.5281/zenodo.5914976)

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -6,11 +6,11 @@ DocMeta.setdocmeta!(Pathfinder, :DocTestSetup, :(using Pathfinder); recursive=tr
 makedocs(;
     modules=[Pathfinder],
     authors="Seth Axen <seth.axen@gmail.com> and contributors",
-    repo="https://github.com/sethaxen/Pathfinder.jl/blob/{commit}{path}#{line}",
+    repo="https://github.com/mlcolab/Pathfinder.jl/blob/{commit}{path}#{line}",
     sitename="Pathfinder.jl",
     format=Documenter.HTML(;
         prettyurls=get(ENV, "CI", "false") == "true",
-        canonical="https://sethaxen.github.io/Pathfinder.jl",
+        canonical="https://mlcolab.github.io/Pathfinder.jl",
         assets=String[],
     ),
     pages=[
@@ -24,4 +24,4 @@ makedocs(;
     ],
 )
 
-deploydocs(; repo="github.com/sethaxen/Pathfinder.jl", devbranch="main", push_preview=true)
+deploydocs(; repo="github.com/mlcolab/Pathfinder.jl", devbranch="main", push_preview=true)


### PR DESCRIPTION
This repo has migrated to the mlcolab org. This PR updates all places in the repo to use this new org name.