### PR TITLE
Clean up Optimization.jl integration

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Pathfinder"
 uuid = "b1d3bc72-d0e7-4279-b92f-7fa5d6d2d454"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.4.11"
+version = "0.4.12"
 
 [deps]
 AbstractDifferentiation = "c29ec348-61ec-40c8-8164-b8c60e9d9f3d"

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -7,22 +7,22 @@ function build_optim_function(f, ∇f; ad_backend=AD.ForwardDiffBackend())
     # Optimization.jl's auto-AD feature.
     # TODO: switch to caching API if available, see
     # https://github.com/JuliaDiff/AbstractDifferentiation.jl/issues/41
-    function grad(res, x, p...)
+    function grad(res, x, p)
         ∇fx = ∇f(x)
         @. res = -∇fx
         return res
     end
-    function hess(res, x, p...)
+    function hess(res, x, p)
         H = only(AD.hessian(ad_backend, f, x))
         @. res = -H
         return res
     end
-    function hv(res, x, v, p...)
+    function hv(res, x, v, p)
         Hv = only(AD.lazy_hessian(ad_backend, f, x) * v)
         @. res = -Hv
         return res
     end
-    return SciMLBase.OptimizationFunction((x, p...) -> -f(x); grad, hess, hv)
+    return SciMLBase.OptimizationFunction{true}((x, p) -> -f(x); grad, hess, hv)
 end
 
 function build_optim_problem(optim_fun, x₀)

--- a/test/multipath.jl
+++ b/test/multipath.jl
@@ -102,8 +102,9 @@ using Transducers
     end
     @testset "errors if no gradient provided" begin
         logp(x) = -sum(abs2, x) / 2
+        f(x, p) = -logp(x)
         init = [randn(5) for _ in 1:10]
-        fun = SciMLBase.OptimizationFunction(logp, Optimization.AutoForwardDiff())
+        fun = SciMLBase.OptimizationFunction(f, Optimization.AutoForwardDiff())
         @test_throws ArgumentError multipathfinder(fun, 10; init)
     end
     @testset "errors if neither dim nor init valid" begin

--- a/test/optimize.jl
+++ b/test/optimize.jl
@@ -22,7 +22,8 @@ include("test_utils.jl")
     ]
     @testset "$name" for (name, fun) in funs
         @test fun isa SciMLBase.OptimizationFunction
-        @test fun.f(x) ≈ -f(x)
+        @test SciMLBase.isinplace(fun)
+        @test fun.f(x, nothing) ≈ -f(x)
         ∇fx = similar(x)
         fun.grad(∇fx, x, nothing)
         @test ∇fx ≈ -∇f(x)

--- a/test/optimize.jl
+++ b/test/optimize.jl
@@ -45,6 +45,7 @@ end
     x0 = randn(n)
     fun = Pathfinder.build_optim_function(f; ad_backend)
     prob = Pathfinder.build_optim_problem(fun, x0)
+    @test SciMLBase.isinplace(prob)
     @test prob isa SciMLBase.OptimizationProblem
     @test prob.f === fun
     @test prob.u0 == x0

--- a/test/optimize.jl
+++ b/test/optimize.jl
@@ -65,9 +65,12 @@ end
     prob = Pathfinder.build_optim_problem(fun, x0)
 
     optimizers = [
-        Optim.BFGS(), Optim.LBFGS(), Optim.ConjugateGradient(), NLopt.Opt(:LD_LBFGS, n)
+        "Optim.BFGS" => Optim.BFGS(),
+        "Optim.LBFGS" => Optim.LBFGS(),
+        "Optim.ConjugateGradient" => Optim.ConjugateGradient(),
+        "NLopt.Opt" => NLopt.Opt(:LD_LBFGS, n),
     ]
-    @testset "$(typeof(optimizer))" for optimizer in optimizers
+    @testset "$name" for (name, optimizer) in optimizers
         optim_sol, optim_trace = Pathfinder.optimize_with_trace(prob, optimizer)
         @test optim_sol isa SciMLBase.OptimizationSolution
         @test optim_trace isa Pathfinder.OptimizationTrace

--- a/test/singlepath.jl
+++ b/test/singlepath.jl
@@ -161,10 +161,11 @@ using Transducers
     end
     @testset "errors if no gradient provided" begin
         logp(x) = -sum(abs2, x) / 2
+        f(x, p) = -logp(x)
         init = randn(5)
-        prob = SciMLBase.OptimizationProblem(logp, init, nothing)
+        prob = SciMLBase.OptimizationProblem(f, init, nothing)
         @test_throws ArgumentError pathfinder(prob)
-        fun = SciMLBase.OptimizationFunction(logp, Optimization.AutoForwardDiff())
+        fun = SciMLBase.OptimizationFunction(f, Optimization.AutoForwardDiff())
         prob = SciMLBase.OptimizationProblem(fun, init, nothing)
         @test_throws ArgumentError pathfinder(prob)
     end


### PR DESCRIPTION
Some recent changes to Optimization.jl (and perhaps also SciMLBase) have caused our CI to error, because we were assuming Optimization supported certain Optim.jl features. e.g. https://github.com/SciML/Optimization.jl/pull/376 clarified that Optimization does not support the Optim kwargs `store_trace` and `extended_trace`, which we were using.

This PR deletes the special `optimize_with_trace` method for Optim.jl optimizers. This means that we need to recompute the gradient at each step of the optimization (not each step of the line search). This is more wasteful, and we should look into using Optim.jl directly without Optimization.jl when an Optim.jl optimizer is provided.

It also brings our usage of OptimizationFunction and OptimizationProblem more in line with what Optimization.jl documents.