### PR TITLE
Store successful OptimizationProblem

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Pathfinder"
 uuid = "b1d3bc72-d0e7-4279-b92f-7fa5d6d2d454"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.5.0"
+version = "0.5.1"
 
 [deps]
 AbstractDifferentiation = "c29ec348-61ec-40c8-8164-b8c60e9d9f3d"

--- a/src/singlepath.jl
+++ b/src/singlepath.jl
@@ -226,7 +226,7 @@ function pathfinder(
         input,
         optimizer,
         rng,
-        optim_solution.prob,
+        optim_prob,
         logp,
         fit_distribution,
         draws,

--- a/src/singlepath.jl
+++ b/src/singlepath.jl
@@ -191,6 +191,7 @@ function pathfinder(
     @unpack (
         itry,
         success,
+        optim_prob,
         optim_solution,
         optim_trace,
         fit_distributions,
@@ -263,7 +264,7 @@ function _pathfinder_try_until_succeed(
         progress_name = "Optimizing (try $itry)"
         result = _pathfinder(rng, _prob, logp; progress_name, kwargs...)
     end
-    return (; itry, result...)
+    return (; itry, optim_prob=_prob, result...)
 end
 
 function _pathfinder(

--- a/test/optimize.jl
+++ b/test/optimize.jl
@@ -115,7 +115,6 @@ end
         @test optim_sol isa SciMLBase.OptimizationSolution
         @test optim_trace isa Pathfinder.OptimizationTrace
         @test optim_trace.points[1] ≈ x0
-        @test optim_sol.prob.u0 ≈ x0
         @test optim_trace.points[end] ≈ μ
         @test optim_sol.u ≈ μ
         @test optim_trace.log_densities ≈ f.(optim_trace.points)


### PR DESCRIPTION
Currently we store in `PathfinderResult` the `OptimizationProblem` that resulted in the final (generally, successful) Pathfinder run. We have been getting this from the returned `OptimizationSolution`. However, the `:prob` property for `OptimizationSolution` is now deprecated and no longer returns an `OptimizationProblem` (see https://github.com/SciML/SciMLBase.jl/pull/286). In this PR, we explicitly store the `OptimizationProblem` ourselves.