### PR TITLE
Fix error in plotting trajectory animations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Pathfinder"
 uuid = "b1d3bc72-d0e7-4279-b92f-7fa5d6d2d454"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.5.1"
+version = "0.5.2"
 
 [deps]
 AbstractDifferentiation = "c29ec348-61ec-40c8-8164-b8c60e9d9f3d"

--- a/docs/src/examples/quickstart.md
+++ b/docs/src/examples/quickstart.md
@@ -72,7 +72,7 @@ function plot_pathfinder_trace(
         trace = trace_points[1:(i + 1)]
         dist = trace_dists[i + 1]
         plot!(
-            first.(trace), last.(trace);
+            first.(trace), getindex.(trace, 2);
             seriestype=:scatterpath, color=:black, msw=0, label="trace",
         )
         covellipse!(


### PR DESCRIPTION
The trace plotting in the quickstart incorrectly plotted the first and last coordinates, when the marginal distribution of interest consists of the first 2 coordinates. This caused the plotted trace to appear to converge to a different point than the mean.