### PR TITLE
Turn Q's into matrices before comparison

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Pathfinder"
 uuid = "b1d3bc72-d0e7-4279-b92f-7fa5d6d2d454"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.5.3"
+version = "0.5.4"
 
 [deps]
 AbstractDifferentiation = "c29ec348-61ec-40c8-8164-b8c60e9d9f3d"

--- a/test/woodbury.jl
+++ b/test/woodbury.jl
@@ -24,7 +24,7 @@ function test_decompositions(W)
     C = I + R * W.D * R'
     UC = cholesky(Symmetric(C)).U
     @test W.UA ≈ UA
-    @test W.Q ≈ Q
+    @test Matrix(W.Q) ≈ Matrix(Q)
     @test W.UC ≈ UC
 end
 


### PR DESCRIPTION
This is in preparation of https://github.com/JuliaLang/julia/pull/46196, and should actually make tests faster since it no longer creates the matrix representation one element at a time, but rather creates it via a single `lmul!(Q, I)` computation.