### PR TITLE
Refactor WoodburyPDMat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Pathfinder"
 uuid = "b1d3bc72-d0e7-4279-b92f-7fa5d6d2d454"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.5.5"
+version = "0.5.6"
 
 [deps]
 AbstractDifferentiation = "c29ec348-61ec-40c8-8164-b8c60e9d9f3d"

--- a/src/integration/dynamichmc.jl
+++ b/src/integration/dynamichmc.jl
@@ -1,48 +1,11 @@
 using .DynamicHMC: DynamicHMC
 
 function DynamicHMC.GaussianKineticEnergy(M⁻¹::WoodburyPDMat)
-    return DynamicHMC.GaussianKineticEnergy(M⁻¹, WoodburyLeftInvFactor(M⁻¹))
+    return DynamicHMC.GaussianKineticEnergy(M⁻¹, inv(pdfactorize(M⁻¹).R))
 end
 
 function DynamicHMC.kinetic_energy(
     κ::DynamicHMC.GaussianKineticEnergy{<:WoodburyPDMat}, p, q=nothing
 )
     return PDMats.quad(κ.M⁻¹, p) / 2
-end
-
-# utility object so we can use DynamicHMC.GaussianKineticEnergy
-struct WoodburyLeftInvFactor{T<:Real,TW<:PDMats.AbstractPDMat{T}} <: AbstractMatrix{T}
-    A::TW
-end
-
-Base.size(L::WoodburyLeftInvFactor, dims::Int...) = size(L.A, dims...)
-
-function LinearAlgebra.mul!(
-    r::StridedVecOrMat{T}, L::WoodburyLeftInvFactor{T}, x::StridedVecOrMat{T}
-) where {T}
-    return invunwhiten!(r, L.A, x)
-end
-
-function Base.Matrix(L::WoodburyLeftInvFactor)
-    W = L.A
-    n, m = size(W.B)
-    k = min(m, n)
-    Lmat = zeros(n, n)
-    Lmat[diagind(Lmat)] .= true
-    @views ldiv!(W.UC, Lmat[1:k, 1:k])
-    lmul!(W.Q, Lmat)
-    ldiv!(W.UA, Lmat)
-    return Lmat
-end
-
-function Base.AbstractMatrix{T}(L::WoodburyLeftInvFactor) where {T}
-    return WoodburyLeftInvFactor(AbstractMatrix{T}(L.A))
-end
-
-function Base.getindex(L::WoodburyLeftInvFactor, i::Int, j::Int)
-    n = size(L, 2)
-    v = zeros(n)
-    v[j] = 1
-    mul!(v, L, v)
-    return v[i]
 end

--- a/src/woodbury.jl
+++ b/src/woodbury.jl
@@ -196,7 +196,7 @@ appendix A of [^Zhang2021].
                 Pathfinder: Parallel quasi-Newton variational inference.
                 arXiv: [2108.03782](https://arxiv.org/abs/2108.03782) [stat.ML]
 
-See [`pdunfactorize`](@ref), [`WoodburyPDRightFactor`](@ref), [`WoodburyPDMat`](@ref)
+See [`pdunfactorize`](@ref), [`WoodburyPDFactorization`](@ref), [`WoodburyPDMat`](@ref)
 """
 function pdfactorize(A::AbstractMatrix, B::AbstractMatrix, D::AbstractMatrix)
     cholA = cholesky(A isa Diagonal ? A : Symmetric(A))

--- a/src/woodbury.jl
+++ b/src/woodbury.jl
@@ -199,7 +199,7 @@ appendix A of [^Zhang2021].
 See [`pdunfactorize`](@ref), [`WoodburyPDRightFactor`](@ref), [`WoodburyPDMat`](@ref)
 """
 function pdfactorize(A::AbstractMatrix, B::AbstractMatrix, D::AbstractMatrix)
-    cholA = cholesky(Symmetric(A))
+    cholA = cholesky(A isa Diagonal ? A : Symmetric(A))
     U = cholA.U
     Q, R = qr(U' \ B)
     V = cholesky(Symmetric(muladd(R, D * R', I))).U


### PR DESCRIPTION
This PR introduces `WoodburyPDFactorization` and `WoodburyPDRightFactor` types, which are now used internally in WoodburyPDMat's methods. These generalize and remove the need for `WoodburyLeftInvFactor`, which was necessary for DynamicHMC integration.

Since `WoodburyPDMat` is documented as internal functionality, these changes are not breaking.