### PR TITLE
Add missing methods for Woodbury matrices

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Pathfinder"
 uuid = "b1d3bc72-d0e7-4279-b92f-7fa5d6d2d454"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.6.0"
+version = "0.6.1"
 
 [deps]
 AbstractDifferentiation = "c29ec348-61ec-40c8-8164-b8c60e9d9f3d"

--- a/src/woodbury.jl
+++ b/src/woodbury.jl
@@ -331,9 +331,7 @@ end
 
 LinearAlgebra.ldiv!(W::WoodburyPDMat, x::AbstractVecOrMat) = ldiv!(factorize(W), x)
 
-function LinearAlgebra.mul!(
-    y::AbstractVecOrMat, W::WoodburyPDMat, x::AbstractVecOrMat, alpha::Number, beta::Number
-)
+function LinearAlgebra.mul!(y::AbstractVecOrMat, W::WoodburyPDMat, x::AbstractVecOrMat)
     copyto!(y, x)
     return lmul!(W, y)
 end

--- a/src/woodbury.jl
+++ b/src/woodbury.jl
@@ -117,13 +117,13 @@ function LinearAlgebra.mul!(
     r::StridedVecOrMat{T}, R::WoodburyPDRightFactor{T}, x::StridedVecOrMat{T}
 ) where {T}
     copyto!(r, x)
-    return lmul!(R, copyto!(r, x))
+    return lmul!(R, r)
 end
-
-function Base.:*(R::WoodburyPDRightFactor, x::StridedVecOrMat)
-    T = Base.promote_eltype(R, x)
-    y = copyto!(similar(x, T), x)
-    return lmul!(R, y)
+function LinearAlgebra.mul!(
+    r::StridedVecOrMat{T}, L::WoodburyPDLeftFactor{T}, x::StridedVecOrMat{T}
+) where {T}
+    copyto!(r, x)
+    return lmul!(L, r)
 end
 
 function LinearAlgebra.lmul!(R::WoodburyPDRightFactor, x::StridedVecOrMat)
@@ -329,8 +329,19 @@ function LinearAlgebra.lmul!(W::WoodburyPDMat, x::AbstractVecOrMat)
     return lmul!(factorize(W), x)
 end
 
-function LinearAlgebra.mul!(y::AbstractVector, W::WoodburyPDMat, x::AbstractVecOrMat)
-    return lmul!(W, copyto!(y, x))
+LinearAlgebra.ldiv!(W::WoodburyPDMat, x::AbstractVecOrMat) = ldiv!(factorize(W), x)
+
+function LinearAlgebra.mul!(
+    y::AbstractVecOrMat, W::WoodburyPDMat, x::AbstractVecOrMat, alpha::Number, beta::Number
+)
+    copyto!(y, x)
+    return lmul!(W, y)
+end
+
+function Base.:\(W::WoodburyPDMat, x::AbstractVecOrMat)
+    y = similar(x, Base.promote_eltype(W, x))
+    copyto!(y, x)
+    return ldiv!(W, y)
 end
 
 function Base.:*(W::WoodburyPDMat, c::Real)

--- a/test/woodbury.jl
+++ b/test/woodbury.jl
@@ -56,6 +56,7 @@ test_factorization(W::WoodburyPDMat) = test_factorization(W.A, W.B, W.D, W.F)
                 @test Z \ x ≈ Zmat \ x
                 @test Z' \ x ≈ Zmat' \ x
                 @test mul!(similar(x), Z, x) ≈ Zmat * x
+                @test mul!(similar(x), Z', x) ≈ Zmat' * x
                 @test lmul!(Z, copy(x)) ≈ Zmat * x
                 @test ldiv!(Z, copy(x)) ≈ Zmat \ x
             end
@@ -230,6 +231,18 @@ end
             @test X ≈ Y
         end
 
+        @testset "ldiv!" begin
+            x = randn(T, n)
+            y = Wmat \ x
+            @test ldiv!(W, x) === x
+            @test x ≈ y
+
+            X = randn(T, n, 5)
+            Y = Wmat \ X
+            @test ldiv!(W, X) === X
+            @test X ≈ Y
+        end
+
         @testset "mul!" begin
             x = randn(T, n)
             y = similar(x)
@@ -254,8 +267,24 @@ end
             x = randn(T, n)
             @test W * x ≈ Wmat * x
 
-            X = randn(T, n)
+            X = randn(T, n, 2)
             @test W * X ≈ Wmat * X
+        end
+
+        @testset "\\" begin
+            x = randn(T, n)
+            @test W \ x ≈ Wmat \ x
+
+            X = randn(T, n, 2)
+            @test W \ X ≈ Wmat \ X
+        end
+
+        @testset "/" begin
+            x = randn(T, n)
+            @test x' / W ≈ x' / Wmat
+
+            X = randn(T, 2, n)
+            @test X / W ≈ X / Wmat
         end
 
         @testset "PDMats.dim" begin


### PR DESCRIPTION
This PR adds a few missing methods for Woodbury matrices and factors. Instead of implement `*` directly, we now implement `mul!` and rely on the fallbacks in base.