### PR TITLE
Update extensions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -59,6 +59,7 @@ UnPack = "1"
 julia = "1.6"
 
 [extras]
+Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
 DynamicHMC = "bbc10e6e-7c05-544b-b16e-64fede858acb"
 DynamicPPL = "366bfd00-2699-11ea-058f-f148b4cae6d8"
 MCMCChains = "c7f686f2-ff18-58e9-bc7b-31028e88f75d"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Pathfinder"
 uuid = "b1d3bc72-d0e7-4279-b92f-7fa5d6d2d454"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.7.2"
+version = "0.7.3"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/Project.toml
+++ b/Project.toml
@@ -32,8 +32,8 @@ MCMCChains = "c7f686f2-ff18-58e9-bc7b-31028e88f75d"
 Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
 
 [extensions]
-DynamicHMCExt = "DynamicHMC"
-TuringExt = ["DynamicPPL", "MCMCChains", "Turing"]
+PathfinderDynamicHMCExt = "DynamicHMC"
+PathfinderTuringExt = ["DynamicPPL", "MCMCChains", "Turing"]
 
 [compat]
 Accessors = "0.1"

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
 version = "0.7.3"
 
 [deps]
-Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Folds = "41a02a25-b8f0-4f67-bc48-60067656b558"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
@@ -26,6 +25,7 @@ Transducers = "28d57a85-8fef-5791-bfe6-a80928e7c999"
 UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [weakdeps]
+Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
 DynamicHMC = "bbc10e6e-7c05-544b-b16e-64fede858acb"
 DynamicPPL = "366bfd00-2699-11ea-058f-f148b4cae6d8"
 MCMCChains = "c7f686f2-ff18-58e9-bc7b-31028e88f75d"
@@ -33,7 +33,7 @@ Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
 
 [extensions]
 PathfinderDynamicHMCExt = "DynamicHMC"
-PathfinderTuringExt = ["DynamicPPL", "MCMCChains", "Turing"]
+PathfinderTuringExt = ["Accessors", "DynamicPPL", "MCMCChains", "Turing"]
 
 [compat]
 Accessors = "0.1"

--- a/ext/PathfinderDynamicHMCExt.jl
+++ b/ext/PathfinderDynamicHMCExt.jl
@@ -1,12 +1,13 @@
 module PathfinderDynamicHMCExt
 
-using PDMats: PDMats
 if isdefined(Base, :get_extension)
-    using Pathfinder: Pathfinder
     using DynamicHMC: DynamicHMC
+    using Pathfinder: Pathfinder
+    using PDMats: PDMats
 else  # using Requires
-    using ..Pathfinder: Pathfinder
     using ..DynamicHMC: DynamicHMC
+    using ..Pathfinder: Pathfinder
+    using ..PDMats: PDMats
 end
 
 function DynamicHMC.GaussianKineticEnergy(M⁻¹::Pathfinder.WoodburyPDMat)

--- a/ext/PathfinderDynamicHMCExt.jl
+++ b/ext/PathfinderDynamicHMCExt.jl
@@ -1,4 +1,4 @@
-module DynamicHMCExt
+module PathfinderDynamicHMCExt
 
 using PDMats: PDMats
 if isdefined(Base, :get_extension)

--- a/ext/PathfinderTuringExt.jl
+++ b/ext/PathfinderTuringExt.jl
@@ -1,16 +1,18 @@
 module PathfinderTuringExt
 
-using Accessors: Accessors
-using Random: Random
 if isdefined(Base, :get_extension)
+    using Accessors: Accessors
     using DynamicPPL: DynamicPPL
     using MCMCChains: MCMCChains
     using Pathfinder: Pathfinder
+    using Random: Random
     using Turing: Turing
 else  # using Requires
+    using ..Accessors: Accessors
     using ..DynamicPPL: DynamicPPL
     using ..MCMCChains: MCMCChains
     using ..Pathfinder: Pathfinder
+    using ..Random: Random
     using ..Turing: Turing
 end
 

--- a/ext/PathfinderTuringExt.jl
+++ b/ext/PathfinderTuringExt.jl
@@ -1,4 +1,4 @@
-module TuringExt
+module PathfinderTuringExt
 
 using Accessors: Accessors
 using Random: Random

--- a/src/Pathfinder.jl
+++ b/src/Pathfinder.jl
@@ -50,12 +50,12 @@ function __init__()
     end
     @static if !isdefined(Base, :get_extension)
         Requires.@require DynamicHMC = "bbc10e6e-7c05-544b-b16e-64fede858acb" begin
-            include("../ext/DynamicHMCExt.jl")
+            include("../ext/PathfinderDynamicHMCExt.jl")
         end
         Requires.@require Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0" begin
             Requires.@require DynamicPPL = "366bfd00-2699-11ea-058f-f148b4cae6d8" begin
                 Requires.@require MCMCChains = "c7f686f2-ff18-58e9-bc7b-31028e88f75d" begin
-                    include("../ext/TuringExt.jl")
+                    include("../ext/PathfinderTuringExt.jl")
                 end
             end
         end

--- a/src/Pathfinder.jl
+++ b/src/Pathfinder.jl
@@ -52,10 +52,12 @@ function __init__()
         Requires.@require DynamicHMC = "bbc10e6e-7c05-544b-b16e-64fede858acb" begin
             include("../ext/PathfinderDynamicHMCExt.jl")
         end
-        Requires.@require Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0" begin
+        Requires.@require Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697" begin
             Requires.@require DynamicPPL = "366bfd00-2699-11ea-058f-f148b4cae6d8" begin
                 Requires.@require MCMCChains = "c7f686f2-ff18-58e9-bc7b-31028e88f75d" begin
-                    include("../ext/PathfinderTuringExt.jl")
+                    Requires.@require Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0" begin
+                        include("../ext/PathfinderTuringExt.jl")
+                    end
                 end
             end
         end

--- a/src/integration/advancedhmc.jl
+++ b/src/integration/advancedhmc.jl
@@ -1,5 +1,5 @@
 using .AdvancedHMC: AdvancedHMC
-using Random
+using .Random
 
 """
     RankUpdateEuclideanMetric{T,M} <: AdvancedHMC.AbstractMetric


### PR DESCRIPTION
This PR updates extension names to be unique, and ensures that Requires always uses relative imports, which is necessary for building sysimages (https://github.com/JuliaArrays/ArrayInterface.jl/pull/387)