### PR TITLE
Fix Transducers to last-compatible version in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,9 +36,9 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v1
+      - uses: julia-actions/julia-buildpkg@v1
       - name: Fix Transducers to last-compatible version
         run: julia --project -e 'using Pkg; Pkg.pin(name="Transducers", version=v"0.4.75")'
-      - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         env:
           JULIA_NUM_THREADS: ${{ matrix.num_threads }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,6 +37,8 @@ jobs:
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
+      - name: Fix Transducers to last-compatible version
+        run: julia --project -e 'using Pkg; Pkg.pin(name="Transducers", version=v"0.4.75")'
       - uses: julia-actions/julia-runtest@v1
         env:
           JULIA_NUM_THREADS: ${{ matrix.num_threads }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,9 +36,9 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v1
-      - uses: julia-actions/julia-buildpkg@v1
       - name: Fix Transducers to last-compatible version
         run: julia --project -e 'using Pkg; Pkg.pin(name="Transducers", version=v"0.4.75")'
+      - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         env:
           JULIA_NUM_THREADS: ${{ matrix.num_threads }}


### PR DESCRIPTION
This PR runs tests against older Transducer versions only to work around #144 breaking our CI. It should be reverted once https://github.com/JuliaFolds/Transducers.jl/issues/557 is resolved, since it covers up potential future breakages