### PR TITLE
Don't show progress bar when multithreading on v1.10

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,6 +29,11 @@ jobs:
         num_threads:
           - 1
           - 2
+        include:
+          - version: '^1.10.0-rc1'
+            os: ubuntu-latest
+            arch: x64
+            num_threads: 1
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Pathfinder"
 uuid = "b1d3bc72-d0e7-4279-b92f-7fa5d6d2d454"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.7.9"
+version = "0.7.11"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/src/multipath.jl
+++ b/src/multipath.jl
@@ -175,7 +175,13 @@ function multipathfinder(
             kwargs...,
         )
     end
-    iter_sp = Transducers.withprogress(_init; interval=1e-3) |> trans
+    iter_sp = if executor isa Folds.ThreadedEx
+        # temporary workaround due to
+        # https://github.com/JuliaFolds2/Transducers.jl/issues/10
+        _init
+    else
+        Transducers.withprogress(_init; interval=1e-3)
+    end |> trans
     pathfinder_results = Folds.collect(iter_sp, executor)
     fit_distributions =
         pathfinder_results |> Transducers.Map(x -> x.fit_distribution) |> collect


### PR DESCRIPTION
As raised in #144, Transducers currently errors if we try to log progress while multithreading the individual single-path runs in multi-path Pathfinder. This PR disables progress logging for `ThreadedEx` executor to sidestep this issue.

Since this only seems to manifest on v1.10.0-rc1 for me, I've added it to the CI.