### PR TITLE
Test docs and integrations with new downgrade CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,6 +47,7 @@ jobs:
       - uses: julia-actions/julia-downgrade-compat-action@v1.1
         with:
           skip: LinearAlgebra,Random,Statistics
+          projects: ., docs
         if: ${{ matrix.downgrade }}
         name: Downgrade dependencies to oldest supported versions
       - uses: julia-actions/julia-buildpkg@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,7 +44,7 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v1
-      - uses: cjdoris/julia-downgrade-compat-action@v1
+      - uses: julia-actions/julia-downgrade-compat-action@v1.1
         with:
           skip: LinearAlgebra,Random,Statistics
         if: ${{ matrix.downgrade }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-downgrade-compat-action@v1.1
         with:
-          skip: LinearAlgebra,Random,Statistics
+          skip: LinearAlgebra,Pathfinder,Random,Statistics
           projects: ., docs
         if: ${{ matrix.downgrade }}
         name: Downgrade dependencies to oldest supported versions

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -67,7 +67,7 @@ jobs:
         include:
           - version: '1'
             downgrade: false
-          - version: '1.6'
+          - version: '1.7'
             downgrade: true
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,9 +44,9 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v1
-      - uses: julia-actions/julia-downgrade-compat-action@v1
+      - uses: julia-actions/julia-downgrade-compat@v1
         with:
-          skip: LinearAlgebra,Pathfinder,Random,Statistics
+          skip: LinearAlgebra,Random,Statistics
         if: ${{ matrix.downgrade }}
         name: Downgrade dependencies to oldest supported versions
       - uses: julia-actions/julia-buildpkg@v1
@@ -74,7 +74,7 @@ jobs:
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}
-      - uses: julia-actions/julia-downgrade-compat-action@v1.1
+      - uses: julia-actions/julia-downgrade-compat@v1.1
         with:
           skip: LinearAlgebra,Pathfinder,Random,Statistics
           projects: ., docs

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,10 +44,9 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v1
-      - uses: julia-actions/julia-downgrade-compat-action@v1.1
+      - uses: julia-actions/julia-downgrade-compat-action@v1
         with:
           skip: LinearAlgebra,Pathfinder,Random,Statistics
-          projects: ., docs
         if: ${{ matrix.downgrade }}
         name: Downgrade dependencies to oldest supported versions
       - uses: julia-actions/julia-buildpkg@v1
@@ -60,17 +59,31 @@ jobs:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
   docs:
-    name: Documentation
+    name: ${{ matrix.downgrade && 'Downgrade / ' || '' }}Documentation - Julia ${{ matrix.version }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - version: '1'
+            downgrade: false
+          - version: '1.6'
+            downgrade: true
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:
-          version: '1'
+          version: ${{ matrix.version }}
+      - uses: julia-actions/julia-downgrade-compat-action@v1.1
+        with:
+          skip: LinearAlgebra,Pathfinder,Random,Statistics
+          projects: ., docs
+        if: matrix.downgrade
+        name: Downgrade dependencies to oldest supported versions
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-docdeploy@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
           GKSwstype: "100" # https://discourse.julialang.org/t/generation-of-documentation-fails-qt-qpa-xcb-could-not-connect-to-display/60988
-  
+        if: matrix.version == '1'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -84,6 +84,5 @@ jobs:
       - uses: julia-actions/julia-docdeploy@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
+          DOCUMENTER_KEY: ${{ matrix.version == '1' && secrets.DOCUMENTER_KEY || '' }}
           GKSwstype: "100" # https://discourse.julialang.org/t/generation-of-documentation-fails-qt-qpa-xcb-could-not-connect-to-display/60988
-        if: matrix.version == '1'

--- a/.github/workflows/IntegrationTests.yml
+++ b/.github/workflows/IntegrationTests.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: x64
-      - uses: julia-actions/julia-downgrade-compat-action@v1.1
+      - uses: julia-actions/julia-downgrade-compat@v1.1
         with:
           skip: LinearAlgebra,Pathfinder,Random,Statistics
           projects: ., test/integration/${{ matrix.package }}

--- a/.github/workflows/IntegrationTests.yml
+++ b/.github/workflows/IntegrationTests.yml
@@ -25,9 +25,10 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: x64
-      - uses: cjdoris/julia-downgrade-compat-action@v1
+      - uses: julia-actions/julia-downgrade-compat-action@v1.1
         with:
-          skip: LinearAlgebra,Random,Statistics
+          skip: LinearAlgebra,Pathfinder,Random,Statistics
+          projects: ., test/integration/${{ matrix.package }}
         if: ${{ matrix.downgrade }}
         name: Downgrade dependencies to oldest supported versions
       - uses: julia-actions/julia-buildpkg@v1


### PR DESCRIPTION
The downgrade compat action has moved to julia-actions and now supports downgrading multiple projects. This PR switches to the new action and now tests integration tests and docs build using downgraded dependencies.