### PR TITLE
Remove Transducers workaround if unneeded

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Pathfinder"
 uuid = "b1d3bc72-d0e7-4279-b92f-7fa5d6d2d454"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.8.5"
+version = "0.8.6"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/src/transducers.jl
+++ b/src/transducers.jl
@@ -10,6 +10,9 @@ function _findmax(x)
     end
 end
 
-# WARNING: Type piracy!
-# https://github.com/JuliaFolds/Transducers.jl/issues/521
-Base.size(x::Transducers.ProgressLoggingFoldable) = size(x.foldable)
+if !hasmethod(size, Tuple{Transducers.ProgressLoggingFoldable})
+    # WARNING: Type piracy!
+    # https://github.com/JuliaFolds/Transducers.jl/issues/521
+    # this method is necessary for Transducers version earlier than v0.4.82
+    Base.size(x::Transducers.ProgressLoggingFoldable) = size(x.foldable)
+end


### PR DESCRIPTION
Transducers v0.4.82 adds the same workaround we use for progress bars, so this PR changes our code to only add the missing method (with type piracy) if it is actually missing.