### PR TITLE
Update Turing example to use `Turing.externalsampler`

### DIFF
--- a/docs/src/examples/turing.md
+++ b/docs/src/examples/turing.md
@@ -5,7 +5,7 @@ This tutorial demonstrates how [Turing](https://turing.ml/stable/) can be used w
 We'll demonstrate with a regression example.
 
 ```@example 1
-using AdvancedHMC, LinearAlgebra, Pathfinder, Random, Turing
+using AdvancedHMC, Pathfinder, Random, Turing
 Random.seed!(39)
 
 @model function regress(x, y)
@@ -21,32 +21,17 @@ nothing # hide
 
 ```@example 1
 model = regress(collect(x), y)
+n_chains = 8
 ```
 
-The first way we can use Turing with Pathfinder is via its mode estimation functionality.
-We can use `Turing.optim_function` to generate a `SciMLBase.OptimizationFunction`, which [`pathfinder`](@ref) and [`multipathfinder`](@ref) can take as inputs.
-
-```@example 1
-fun = optim_function(model, MAP(); constrained=false)
-```
-
-```@example 1
-dim = length(fun.init())
-pathfinder(fun.func; dim)
-```
-
-```@example 1
-multipathfinder(fun.func, 1_000; dim, nruns=8)
-```
-
-However, for convenience, `pathfinder` and `multipathfinder` can take Turing models as inputs and produce `MCMCChains.Chains` objects as outputs.
+For convenience, [`pathfinder`](@ref) and [`multipathfinder`](@ref) can take Turing models as inputs and produce `MCMCChains.Chains` objects as outputs.
 
 ```@example 1
 result_single = pathfinder(model; ndraws=1_000)
 ```
 
 ```@example 1
-result_multi = multipathfinder(model, 1_000; nruns=8)
+result_multi = multipathfinder(model, 1_000; nruns=n_chains)
 ```
 
 Here, the Pareto shape diagnostic indicates that it is likely safe to use these draws to compute posterior estimates.
@@ -60,52 +45,34 @@ result_multi.draws_transformed
 We can also use these posterior draws to initialize MCMC sampling.
 
 ```@example 1
-init_params = collect.(eachrow(result_multi.draws_transformed.value[1:4, :, 1]))
+init_params = collect.(eachrow(result_multi.draws_transformed.value[1:n_chains, :, 1]))
 ```
 
 ```@example 1
-chns = sample(model, Turing.NUTS(), MCMCThreads(), 1_000, 4; init_params, progress=false)
+chns = sample(model, Turing.NUTS(), MCMCThreads(), 1_000, n_chains; init_params, progress=false)
 ```
 
-To use Pathfinder's estimate of the metric and skip warm-up, at the moment one needs to use AdvancedHMC directly.
+We can use Pathfinder's estimate of the metric and only perform enough warm-up to tune the step size.
 
 ```@example 1
-ℓπ(x) = -fun.func.f(x, nothing)
-function ∂ℓπ∂θ(x)
-    g = similar(x)
-    fun.func.grad(g, x, nothing)
-    rmul!(g, -1)
-    return ℓπ(x), g
-end
-
-ndraws = 1_000
-nadapts = 50
 inv_metric = result_multi.pathfinder_results[1].fit_distribution.Σ
 metric = Pathfinder.RankUpdateEuclideanMetric(inv_metric)
-hamiltonian = Hamiltonian(metric, ℓπ, ∂ℓπ∂θ)
-ϵ = find_good_stepsize(hamiltonian, init_params[1])
-integrator = Leapfrog(ϵ)
-kernel = HMCKernel(Trajectory{MultinomialTS}(integrator, GeneralisedNoUTurn()))
-adaptor = StepSizeAdaptor(0.8, integrator)
-samples, stats = sample(
-    hamiltonian,
-    kernel,
-    init_params[1],
-    ndraws + nadapts,
-    adaptor,
-    nadapts;
-    drop_warmup=true,
+kernel = HMCKernel(Trajectory{MultinomialTS}(Leapfrog(0.0), GeneralisedNoUTurn()))
+adaptor = StepSizeAdaptor(0.8, 1.0)  # adapt only the step size
+nuts = AdvancedHMC.HMCSampler(kernel, metric, adaptor)
+
+n_adapts = 50
+n_draws = 1_000
+chns = sample(
+    model,
+    externalsampler(nuts),
+    MCMCThreads(),
+    n_draws + n_adapts,
+    n_chains;
+    n_adapts,
+    init_params,
     progress=false,
-)
-```
-
-Now we pack the samples into an `MCMCChains.Chains`.
-For this we use the utility [`Pathfinder.flattened_varnames_list`](@ref).
-
-```@example 1
-samples_transformed = reduce(vcat, fun.transform.(samples)')
-varnames = Pathfinder.flattened_varnames_list(model)
-chns = MCMCChains.Chains(samples_transformed, varnames)
+)[n_adapts + 1:end, :, :]  # drop warm-up draws
 ```
 
 See [Initializing HMC with Pathfinder](@ref) for further examples.

--- a/src/integration/advancedhmc.jl
+++ b/src/integration/advancedhmc.jl
@@ -55,6 +55,8 @@ AdvancedHMC.renew(::RankUpdateEuclideanMetric, M⁻¹) = RankUpdateEuclideanMetr
 
 Base.size(metric::RankUpdateEuclideanMetric, dim...) = size(metric.M⁻¹.A.diag, dim...)
 
+Base.eltype(metric::RankUpdateEuclideanMetric) = eltype(metric.M⁻¹)
+
 function Base.show(io::IO, metric::RankUpdateEuclideanMetric)
     print(io, "RankUpdateEuclideanMetric(diag=$(diag(metric.M⁻¹)))")
     return nothing

--- a/test/integration/AdvancedHMC/runtests.jl
+++ b/test/integration/AdvancedHMC/runtests.jl
@@ -82,6 +82,7 @@ end
         @test metric2.M⁻¹ ≈ I
         @test size(metric2) == (3,)
         @test size(metric2, 2) == 1
+        @test eltype(metric2) === Float64
         metric2 = Pathfinder.RankUpdateEuclideanMetric((4,))
         @test metric2.M⁻¹ ≈ I
         @test size(metric2) == (4,)


### PR DESCRIPTION
This substantially reduces the complexity of the example and frees us from needing `flattened_varnames_list` in our API.