### PR TITLE
Use new Julia language features since v1.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.9.14"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Folds = "41a02a25-b8f0-4f67-bc48-60067656b558"
 IrrationalConstants = "92d709cd-6900-40b7-9082-c6be49f344b6"
@@ -38,6 +39,7 @@ PathfinderTuringExt = ["Accessors", "DynamicPPL", "MCMCChains", "Turing"]
 [compat]
 ADTypes = "0.2.5, 1"
 Accessors = "0.1.12"
+Compat = "3.47.0, 4.10.0"
 Distributions = "0.25.87"
 DynamicHMC = "3.4.0"
 DynamicPPL = "0.25.2, 0.27, 0.28, 0.29, 0.30, 0.31, 0.32, 0.33, 0.34, 0.35"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Pathfinder"
 uuid = "b1d3bc72-d0e7-4279-b92f-7fa5d6d2d454"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.9.13"
+version = "0.9.14"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/Project.toml
+++ b/Project.toml
@@ -39,7 +39,7 @@ PathfinderTuringExt = ["Accessors", "DynamicPPL", "MCMCChains", "Turing"]
 [compat]
 ADTypes = "0.2.5, 1"
 Accessors = "0.1.12"
-Compat = "3.47.0, 4.10.0"
+Compat = "4.10.0"
 Distributions = "0.25.87"
 DynamicHMC = "3.4.0"
 DynamicPPL = "0.25.2, 0.27, 0.28, 0.29, 0.30, 0.31, 0.32, 0.33, 0.34, 0.35"

--- a/docs/src/examples/initializing-hmc.md
+++ b/docs/src/examples/initializing-hmc.md
@@ -58,11 +58,8 @@ function RegressionProblem(x, J, y)
 end
 
 function (prob::RegressionProblem)(θ)
-    σ = θ.σ
-    α = θ.α
-    β = θ.β
-    z = prob.z
-    y = prob.y
+    (; σ, α, β) = θ
+    (; z, y) = prob
     lp = normlogpdf(σ) + logtwo
     lp += normlogpdf(α)
     lp += sum(normlogpdf, β)
@@ -113,7 +110,7 @@ Here we just need to pass one of the draws as the initial point `q`:
 
 ```@example 1
 result_dhmc1 = mcmc_with_warmup(
-    Random.GLOBAL_RNG,
+    Random.default_rng(),
     ∇P,
     ndraws;
     initialization=(; q=init_params),
@@ -127,7 +124,7 @@ To start with Pathfinder's inverse metric estimate, we just need to initialize a
 
 ```@example 1
 result_dhmc2 = mcmc_with_warmup(
-    Random.GLOBAL_RNG,
+    Random.default_rng(),
     ∇P,
     ndraws;
     initialization=(; q=init_params, κ=GaussianKineticEnergy(inv_metric)),
@@ -145,7 +142,7 @@ To turn off metric adaptation entirely and use Pathfinder's estimate, we just se
 
 ```@example 1
 result_dhmc3 = mcmc_with_warmup(
-    Random.GLOBAL_RNG,
+    Random.default_rng(),
     ∇P,
     ndraws;
     initialization=(; q=init_params, κ=GaussianKineticEnergy(inv_metric)),

--- a/ext/PathfinderDynamicHMCExt.jl
+++ b/ext/PathfinderDynamicHMCExt.jl
@@ -1,14 +1,8 @@
 module PathfinderDynamicHMCExt
 
-if isdefined(Base, :get_extension)
-    using DynamicHMC: DynamicHMC
-    using Pathfinder: Pathfinder
-    using PDMats: PDMats
-else  # using Requires
-    using ..DynamicHMC: DynamicHMC
-    using ..Pathfinder: Pathfinder
-    using ..PDMats: PDMats
-end
+using DynamicHMC: DynamicHMC
+using Pathfinder: Pathfinder
+using PDMats: PDMats
 
 function DynamicHMC.GaussianKineticEnergy(M⁻¹::Pathfinder.WoodburyPDMat)
     return DynamicHMC.GaussianKineticEnergy(M⁻¹, inv(Pathfinder.pdfactorize(M⁻¹).R))

--- a/ext/PathfinderTuringExt.jl
+++ b/ext/PathfinderTuringExt.jl
@@ -1,18 +1,10 @@
 module PathfinderTuringExt
 
-if isdefined(Base, :get_extension)
-    using Accessors: Accessors
-    using DynamicPPL: DynamicPPL
-    using MCMCChains: MCMCChains
-    using Pathfinder: Pathfinder
-    using Turing: Turing
-else  # using Requires
-    using ..Accessors: Accessors
-    using ..DynamicPPL: DynamicPPL
-    using ..MCMCChains: MCMCChains
-    using ..Pathfinder: Pathfinder
-    using ..Turing: Turing
-end
+using Accessors: Accessors
+using DynamicPPL: DynamicPPL
+using MCMCChains: MCMCChains
+using Pathfinder: Pathfinder
+using Turing: Turing
 
 """
     create_log_density_problem(model::DynamicPPL.Model)

--- a/src/Pathfinder.jl
+++ b/src/Pathfinder.jl
@@ -53,20 +53,6 @@ function __init__()
     Requires.@require AdvancedHMC = "0bf59076-c3b1-5ca4-86bd-e02cd72cde3d" begin
         include("integration/advancedhmc.jl")
     end
-    @static if !isdefined(Base, :get_extension)
-        Requires.@require DynamicHMC = "bbc10e6e-7c05-544b-b16e-64fede858acb" begin
-            include("../ext/PathfinderDynamicHMCExt.jl")
-        end
-        Requires.@require Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697" begin
-            Requires.@require DynamicPPL = "366bfd00-2699-11ea-058f-f148b4cae6d8" begin
-                Requires.@require MCMCChains = "c7f686f2-ff18-58e9-bc7b-31028e88f75d" begin
-                    Requires.@require Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0" begin
-                        include("../ext/PathfinderTuringExt.jl")
-                    end
-                end
-            end
-        end
-    end
 end
 
 end

--- a/src/Pathfinder.jl
+++ b/src/Pathfinder.jl
@@ -1,6 +1,7 @@
 module Pathfinder
 
 using ADTypes: ADTypes
+using Compat: Compat
 using Distributions: Distributions
 using Folds: Folds
 using IrrationalConstants: log2π
@@ -22,6 +23,9 @@ using Transducers: Transducers
 
 export PathfinderResult, MultiPathfinderResult
 export pathfinder, multipathfinder
+
+# Declare the public API
+Compat.@compat public pathfinder, multipathfinder, PathfinderResult, MultiPathfinderResult
 
 const DEFAULT_HISTORY_LENGTH = 6
 const DEFAULT_LINE_SEARCH = LineSearches.HagerZhang()

--- a/src/multipath.jl
+++ b/src/multipath.jl
@@ -99,7 +99,7 @@ $(_ARGUMENT_DOCSTRING)
 - `ndraws_per_run::Int`: The number of draws to take for each component before resampling.
     Defaults to a number such that `ndraws_per_run * nruns > ndraws`.
 - `importance::Bool=true`: Perform Pareto smoothed importance resampling of draws.
-- `rng::AbstractRNG=Random.GLOBAL_RNG`: Pseudorandom number generator. It is recommended to
+- `rng::AbstractRNG=Random.default_rng()`: Pseudorandom number generator. It is recommended to
     use a parallelization-friendly PRNG like the default PRNG on Julia 1.7 and up.
 - `executor::Transducers.Executor`: Transducers.jl executor that determines if and how to
     run the single-path runs in parallel, defaulting to
@@ -138,7 +138,7 @@ function multipathfinder(
     nruns::Int=init === nothing ? -1 : length(init),
     ndraws_elbo::Int=DEFAULT_NDRAWS_ELBO,
     ndraws_per_run::Int=max(ndraws_elbo, cld(ndraws, max(nruns, 1))),
-    rng::Random.AbstractRNG=Random.GLOBAL_RNG,
+    rng::Random.AbstractRNG=Random.default_rng(),
     history_length::Int=DEFAULT_HISTORY_LENGTH,
     optimizer=default_optimizer(history_length),
     executor::Transducers.Executor=Transducers.SequentialEx(),

--- a/src/multipath.jl
+++ b/src/multipath.jl
@@ -47,7 +47,7 @@ function Base.show(io::IO, ::MIME"text/plain", result::MultiPathfinderResult)
     println(io, "Multi-path Pathfinder result")
     println(io, "  runs: $(length(result.pathfinder_results))")
     print(io, "  draws: $(size(result.draws, 2))")
-    psis_result = result.psis_result
+    (; psis_result) = result
     if psis_result !== nothing
         println(io)
         k = psis_result.pareto_shape

--- a/src/resample.jl
+++ b/src/resample.jl
@@ -8,7 +8,7 @@ If `log_weights` is provided, perform Pareto smoothed importance resampling.
 """
 function resample(rng, x, log_ratios, ndraws)
     psis_result = PSIS.psis(log_ratios)
-    weights = psis_result.weights
+    (; weights) = psis_result
     pweights = StatsBase.ProbabilityWeights(weights, one(eltype(weights)))
     return StatsBase.sample(rng, x, pweights, ndraws; replace=true), psis_result
 end

--- a/src/singlepath.jl
+++ b/src/singlepath.jl
@@ -344,7 +344,7 @@ struct UniformSampler{T<:Real}
 end
 
 function (s::UniformSampler)(rng::Random.AbstractRNG, point)
-    scale = s.scale
+    (; scale) = s
     @. point = rand(rng) * 2scale - scale
     return point
 end

--- a/src/singlepath.jl
+++ b/src/singlepath.jl
@@ -158,7 +158,7 @@ function pathfinder(fun; input=fun, adtype::ADTypes.AbstractADType=default_ad(),
 end
 function pathfinder(
     optim_fun::SciMLBase.OptimizationFunction;
-    rng=Random.GLOBAL_RNG,
+    rng=Random.default_rng(),
     init=nothing,
     dim::Int=-1,
     init_scale=2,
@@ -181,7 +181,7 @@ function pathfinder(
 end
 function pathfinder(
     prob::SciMLBase.OptimizationProblem;
-    rng::Random.AbstractRNG=Random.GLOBAL_RNG,
+    rng::Random.AbstractRNG=Random.default_rng(),
     history_length::Int=DEFAULT_HISTORY_LENGTH,
     optimizer=default_optimizer(history_length),
     ndraws_elbo::Int=DEFAULT_NDRAWS_ELBO,

--- a/test/integration/AdvancedHMC/runtests.jl
+++ b/test/integration/AdvancedHMC/runtests.jl
@@ -21,11 +21,8 @@ struct RegressionProblem{X,Y}
 end
 
 function (prob::RegressionProblem)(θ)
-    σ = θ.σ
-    α = θ.α
-    β = θ.β
-    x = prob.x
-    y = prob.y
+    (; σ, α, β) = θ
+    (; x, y) = prob
     lp = normlogpdf(σ) + logtwo
     lp += normlogpdf(α)
     lp += sum(normlogpdf, β)

--- a/test/integration/DynamicHMC/runtests.jl
+++ b/test/integration/DynamicHMC/runtests.jl
@@ -81,7 +81,7 @@ end
         trans = as((σ=asℝ₊, α=asℝ, β=as(Array, size(X, 2))))
         P = TransformedLogDensity(trans, prob)
         ∇P = ADgradient(:ForwardDiff, P)
-        rng = Random.GLOBAL_RNG
+        rng = Random.default_rng()
 
         result_hmc1 = mcmc_with_warmup(rng, ∇P, ndraws; reporter=NoProgressReport())
 

--- a/test/integration/DynamicHMC/runtests.jl
+++ b/test/integration/DynamicHMC/runtests.jl
@@ -20,11 +20,8 @@ struct RegressionProblem{X,Y}
 end
 
 function (prob::RegressionProblem)(θ)
-    σ = θ.σ
-    α = θ.α
-    β = θ.β
-    x = prob.x
-    y = prob.y
+    (; σ, α, β) = θ
+    (; x, y) = prob
     lp = normlogpdf(σ) + logtwo
     lp += normlogpdf(α)
     lp += sum(normlogpdf, β)

--- a/test/integration/Turing/runtests.jl
+++ b/test/integration/Turing/runtests.jl
@@ -1,11 +1,7 @@
 using LogDensityProblems, LinearAlgebra, Pathfinder, Random, Test, Turing
 using Turing.Bijectors
 
-if isdefined(Base, :get_extension)
-    PathfinderTuringExt = Base.get_extension(Pathfinder, :PathfinderTuringExt)
-else
-    PathfinderTuringExt = Pathfinder.PathfinderTuringExt
-end
+PathfinderTuringExt = Base.get_extension(Pathfinder, :PathfinderTuringExt)
 
 Random.seed!(0)
 

--- a/test/singlepath.jl
+++ b/test/singlepath.jl
@@ -33,7 +33,7 @@ using Transducers
             @test result.rng === rng
             @test result.optimizer ===
                 Pathfinder.default_optimizer(Pathfinder.DEFAULT_HISTORY_LENGTH)
-            fit_distribution = result.fit_distribution
+            (; fit_distribution) = result
             @test fit_distribution isa MvNormal
             @test fit_distribution.μ ≈ zeros(dim) atol = 1e-6
             @test fit_distribution.Σ isa Pathfinder.WoodburyPDMat

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -8,10 +8,10 @@ function rand_pd_mat(rng, T, n)
     U = qr(randn(rng, T, n, n)).Q
     return Matrix(Symmetric(U * rand_pd_diag_mat(rng, T, n) * U'))
 end
-rand_pd_mat(T, n) = rand_pd_mat(Random.GLOBAL_RNG, T, n)
+rand_pd_mat(T, n) = rand_pd_mat(Random.default_rng(), T, n)
 
 rand_pd_diag_mat(rng, T, n) = Diagonal(rand(rng, T, n))
-rand_pd_diag_mat(T, n) = rand_pd_diag_mat(Random.GLOBAL_RNG, T, n)
+rand_pd_diag_mat(T, n) = rand_pd_diag_mat(Random.default_rng(), T, n)
 
 # defined for testing purposes
 function Pathfinder.rand_and_logpdf(rng, dist, ndraws)


### PR DESCRIPTION
Now that our Julia lower bound is v1.10, this PR attempts to, where possible, remove outdated syntax and conventions and also use new syntax. In particular the changes are:
- Replace `GLOBAL_RNG` with `default_rng()` (add in v1.3)
- Use destructuring syntax everywhere we can (add in v1.7)
- Remove outdated check for `get_extension` (added in v1.9)
- Declare the public API (added in v1.11). Use `Compat.@compat` to make `public` a no-op in v1.10

Only the latter change is functional, and the user shouldn't notice any difference anywhere.