### PR TITLE
Remove redundant public declarations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "0.9.15"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
-Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Folds = "41a02a25-b8f0-4f67-bc48-60067656b558"
 IrrationalConstants = "92d709cd-6900-40b7-9082-c6be49f344b6"
@@ -38,7 +37,6 @@ PathfinderTuringExt = ["Accessors", "DynamicPPL", "MCMCChains", "Turing"]
 [compat]
 ADTypes = "0.2.5, 1"
 Accessors = "0.1.12"
-Compat = "4.10.0"
 Distributions = "0.25.87"
 DynamicHMC = "3.4.0"
 DynamicPPL = "0.25.2, 0.27, 0.28, 0.29, 0.30, 0.31, 0.32, 0.33, 0.34, 0.35"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Pathfinder"
 uuid = "b1d3bc72-d0e7-4279-b92f-7fa5d6d2d454"
 authors = ["Seth Axen <seth.axen@gmail.com> and contributors"]
-version = "0.9.15"
+version = "0.9.16"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/Pathfinder.jl
+++ b/src/Pathfinder.jl
@@ -1,7 +1,6 @@
 module Pathfinder
 
 using ADTypes: ADTypes
-using Compat: Compat
 using Distributions: Distributions
 using Folds: Folds
 using IrrationalConstants: log2π
@@ -20,11 +19,9 @@ using Statistics: Statistics
 using StatsBase: StatsBase
 using Transducers: Transducers
 
+# Declare and export the public API
 export PathfinderResult, MultiPathfinderResult
 export pathfinder, multipathfinder
-
-# Declare the public API
-Compat.@compat public pathfinder, multipathfinder, PathfinderResult, MultiPathfinderResult
 
 const DEFAULT_HISTORY_LENGTH = 6
 const DEFAULT_LINE_SEARCH = LineSearches.HagerZhang()


### PR DESCRIPTION
In Julia <v1.12, `export` is now interpreted as implicitly declaring the exported symbol as being public. In Julia v1.12, this is made explicit (see https://github.com/JuliaLang/julia/blob/c175ace780d72340c0653fa5781c09de660e9c0e/NEWS.md?plain=1#L51), and declaring an exported symbol as also `public` raises an error.