### PR TITLE
Update external reference to AdvancedHMC docs

### DIFF
--- a/src/integration/advancedhmc.jl
+++ b/src/integration/advancedhmc.jl
@@ -4,8 +4,8 @@ using .Random
 """
     RankUpdateEuclideanMetric{T,M} <: AdvancedHMC.AbstractMetric
 
-A Gaussian Euclidean [metric](@extref AdvancedHMC Hamiltonian-mass-matrix-(metric)) whose
-inverse is constructed by rank-updates.
+A Gaussian Euclidean metric (mass matrix) whose inverse is constructed by
+rank-updates.
 
 # Constructors
 
@@ -29,6 +29,8 @@ julia> W = Pathfinder.WoodburyPDMat(Diagonal([0.1, 0.2]), [0.7 0.2]', Diagonal([
 
 julia> Pathfinder.RankUpdateEuclideanMetric(W)
 RankUpdateEuclideanMetric(diag=[0.247, 0.21200000000000002])
+
+See also: The AdvancedHMC [metric](@extref AdvancedHMC hamiltonian_mm) documentation.
 ```
 """
 RankUpdateEuclideanMetric


### PR DESCRIPTION
AdvancedHMC recently updated their docs and the heading we were linking to now has a different entry in the sphinx inventory. This PR updates to point to the same heading.